### PR TITLE
Add portals option

### DIFF
--- a/search-service.go
+++ b/search-service.go
@@ -33,6 +33,7 @@ type searchData struct {
 	QueryGroup []map[string]string `json:"query"`
 	Limit      string              `json:"limit,omitempty"`
 	Offset     string              `json:"offset,omitempty"`
+	Portal     []string            `json:"portal,omitempty"`
 	Sort       []*Sorter           `json:"sort,omitempty"`
 }
 
@@ -59,6 +60,12 @@ func (s *searchService) SetLimit(limit string) *searchService {
 	s.seachData.Limit = limit
 	return s
 }
+
+func (s *searchService) SetPortals(portal []string) *searchService {
+	s.seachData.Portal = portal
+	return s
+}
+
 func (s *searchService) Sorters(sorters ...*Sorter) *searchService {
 	s.seachData.Sort = sorters
 	return s

--- a/search-service.go
+++ b/search-service.go
@@ -33,7 +33,7 @@ type searchData struct {
 	QueryGroup []map[string]string `json:"query"`
 	Limit      string              `json:"limit,omitempty"`
 	Offset     string              `json:"offset,omitempty"`
-	Portal     []string            `json:"portal,omitempty"`
+	Portal     []string            `json:"portal"`
 	Sort       []*Sorter           `json:"sort,omitempty"`
 }
 


### PR DESCRIPTION
When sending a filemaker search request, all portals are included by default, leading to long response times when there are many/complex portals available.

This PR introduce the option to set the portals used in a search request, as available in the Filemaker API spec. See https://help.claris.com/archive/docs/18/en/dataapi/#perform-a-find-request.